### PR TITLE
CMSから取得に成功した商品のクラスを外す処理を修正

### DIFF
--- a/item-list.html
+++ b/item-list.html
@@ -117,15 +117,15 @@
     </div>
   </div>
 
-  
-  
+
+
   <!-- コンテンツ読み込みに成功したときは、display:none を外す処理 -->
   <script>
     window.addEventListener('spearlyCmsAfterInit', (evt) => {
       // 取得成功したものについては、display: none を外す
       const contentId = evt.cmsContentId;
-      const className = `.c-item-list__item-from-spearly-${contentId}`;
-      const targetElement = document.querySelector(className);
+      const className = `c-item-list__item-from-spearly-${contentId}`;
+      const targetElement = document.querySelector(`.${className}`);
       targetElement.classList.remove(className);
     })
   </script>
@@ -148,7 +148,7 @@
       </style>
       <!-- 商品個別 (Spearly から) -->
 
-      <li 
+      <li
         class="c-product-list__item c-item-list__item-from-spearly-<{$productlist[num].id }>"
         cms-item
         cms-content-type="sample-ab-testing"
@@ -172,7 +172,7 @@
           </div>
           <{/if}>
           <{/foreach}>
-          
+
         </a>
         <{* 商品名 *}>
         <a href="<{$productlist[num].link_url}>" class="c-product-list__name">
@@ -214,7 +214,7 @@
 
       <!-- コンテンツが取得できなかった場合に表示される要素-->
       <li class="c-product-list__item backup-<{$productlist[num].id}>">
-        
+
         <{* 商品画像 *}>
         <a href="<{$productlist[num].link_url}>" class="c-product-list__image-wrap c-image-wrap c-image-wrap--link">
           <{* 商品画像1枚目 *}>
@@ -233,7 +233,7 @@
           </div>
           <{/if}>
           <{/foreach}>
-          
+
         </a>
         <{* 商品名 *}>
         <a href="<{$productlist[num].link_url}>" class="c-product-list__name">


### PR DESCRIPTION
`classList.remove`で削除するクラス名に`.` は不要で、そこの処理が誤っておりました 🙇 